### PR TITLE
correct a small typo ;)

### DIFF
--- a/cli_tools/src/kritis3m_pki.c
+++ b/cli_tools/src/kritis3m_pki.c
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
                 ERROR_OUT("unable to allocate buffer");
 
         /* Initialize the PKI libraries */
-        krits3m_pki_configuration pki_lib_config = {
+        kritis3m_pki_configuration pki_lib_config = {
                 .logging_enabled = true,
                 .log_level = LOG_LVL_GET(),
                 .custom_log_callback = pki_lib_log_callback,

--- a/cli_tools/src/kritis3m_se_importer.c
+++ b/cli_tools/src/kritis3m_se_importer.c
@@ -168,7 +168,7 @@ int main(int argc, char** argv)
                 ERROR_OUT("unable to allocate buffer");
 
         /* Initialize the PKI libraries */
-        krits3m_pki_configuration pki_lib_config = {
+        kritis3m_pki_configuration pki_lib_config = {
                 .logging_enabled = true,
                 .log_level = LOG_LVL_GET(),
                 .custom_log_callback = pki_lib_log_callback,

--- a/library/include/kritis3m_pki_common.h
+++ b/library/include/kritis3m_pki_common.h
@@ -43,7 +43,7 @@ enum KRITIS3M_PKI_LOG_LEVEL
 
 
 /* Function pointer type for custom logging callbacks. */
-typedef void (*krits3m_pki_custom_log_callback)(int32_t level, char const* message);
+typedef void (*kritis3m_pki_custom_log_callback)(int32_t level, char const* message);
 
 
 /* Data structure for the library configuration */
@@ -51,19 +51,19 @@ typedef struct
 {
         bool logging_enabled;
         int32_t log_level;
-        krits3m_pki_custom_log_callback custom_log_callback;
+        kritis3m_pki_custom_log_callback custom_log_callback;
 }
-krits3m_pki_configuration;
+kritis3m_pki_configuration;
 
 
 /* Initialize the KRITIS3M PKI libraries.
  *
- * Parameter is a pointer to a filled krits3m_pki_configuration structure.
+ * Parameter is a pointer to a filled kritis3m_pki_configuration structure.
  *
  * Returns KRITIS3M_PKI_SUCCESS on success, negative error code in case of an error
  * (error message is logged to the console).
  */
-int kritis3m_pki_init(krits3m_pki_configuration const* config);
+int kritis3m_pki_init(kritis3m_pki_configuration const* config);
 
 
 /* Enable/disable logging infrastructure.
@@ -81,7 +81,7 @@ int kritis3m_pki_enable_logging(bool enable);
  *
  * Returns KRITIS3M_PKI_SUCCESS on success, negative error code in case of an error.
  */
-int kritis3m_pki_set_custom_log_callback(krits3m_pki_custom_log_callback new_callback);
+int kritis3m_pki_set_custom_log_callback(kritis3m_pki_custom_log_callback new_callback);
 
 
 /* Update the log level.

--- a/library/src/kritis3m_pki_common.c
+++ b/library/src/kritis3m_pki_common.c
@@ -45,12 +45,12 @@ char const* kritis3m_pki_error_message(int error_code)
 
 /* Initialize the KRITIS3M PKI libraries.
  *
- * Parameter is a pointer to a filled krits3m_pki_configuration structure.
+ * Parameter is a pointer to a filled kritis3m_pki_configuration structure.
  *
  * Returns KRITIS3M_PKI_SUCCESS on success, negative error code in case of an error
  * (error message is logged to the console).
  */
-int kritis3m_pki_init(krits3m_pki_configuration const* config)
+int kritis3m_pki_init(kritis3m_pki_configuration const* config)
 {
         int ret = KRITIS3M_PKI_SUCCESS;
 

--- a/library/src/kritis3m_pki_logging.c
+++ b/library/src/kritis3m_pki_logging.c
@@ -11,7 +11,7 @@
 
 /* Internal logging variables */
 static int32_t log_level = KRITIS3M_PKI_LOG_LEVEL_ERR;
-static krits3m_pki_custom_log_callback log_callback = NULL;
+static kritis3m_pki_custom_log_callback log_callback = NULL;
 static bool log_enabled = false;
 
 /* Internal method declarations */
@@ -51,7 +51,7 @@ int kritis3m_pki_enable_logging(bool enable)
  *
  * Returns KRITIS3M_PKI_SUCCESS on success, negative error code in case of an error.
  */
-int kritis3m_pki_set_custom_log_callback(krits3m_pki_custom_log_callback new_callback)
+int kritis3m_pki_set_custom_log_callback(kritis3m_pki_custom_log_callback new_callback)
 {
 	/* Update the internal pointer to the callback. */
 	if (new_callback != NULL)


### PR DESCRIPTION
Ich habe einen kleinen Tippfehler gefunden. Ein `i` hat bei `kriti3m_` gefehlt. :)