### PR TITLE
Feature est parse response

### DIFF
--- a/library/include/kritis3m_pki_client.h
+++ b/library/include/kritis3m_pki_client.h
@@ -86,12 +86,6 @@ KRITIS3M_PKI_API int signingRequest_finalize(SigningRequest* request,
 /* Free the memory of given SigningRequest */
 KRITIS3M_PKI_API void signingRequest_free(SigningRequest* request);
 
-enum ResponseType
-{
-        RESPONSE_TYPE_CERT,
-        RESPONSE_TYPE_CHAIN,
-};
-
 // see https://github.com/wolfSSL/wolfssl-examples/blob/master/pkcs7/signedData-p7b.c for reference
 // @info out_buf_size does not reflect the size of the allocated buffer. To avaoid multiple allocations, @param out_buf allocates MAX_DECODE_SIZE bytes.
 KRITIS3M_PKI_API int

--- a/library/include/kritis3m_pki_client.h
+++ b/library/include/kritis3m_pki_client.h
@@ -80,9 +80,22 @@ KRITIS3M_PKI_API int signingRequest_init(SigningRequest* request,
 KRITIS3M_PKI_API int signingRequest_finalize(SigningRequest* request,
                                              PrivateKey* key,
                                              uint8_t* buffer,
-                                             size_t* buffer_size);
+                                             size_t* buffer_size,
+                                             bool remove_pem_header);
 
 /* Free the memory of given SigningRequest */
 KRITIS3M_PKI_API void signingRequest_free(SigningRequest* request);
+
+enum ResponseType
+{
+        RESPONSE_TYPE_CERT,
+        RESPONSE_TYPE_CHAIN,
+};
+
+KRITIS3M_PKI_API int parseESTResponse(uint8_t* buffer,
+                                      size_t buffer_size,
+                                      uint8_t** out_buf,
+                                      int* out_buf_size,
+                                      enum ResponseType response_type);
 
 #endif /* KRITIS3M_PKI_CLIENT_H */

--- a/library/include/kritis3m_pki_client.h
+++ b/library/include/kritis3m_pki_client.h
@@ -92,10 +92,9 @@ enum ResponseType
         RESPONSE_TYPE_CHAIN,
 };
 
-KRITIS3M_PKI_API int parseESTResponse(uint8_t* buffer,
-                                      size_t buffer_size,
-                                      uint8_t** out_buf,
-                                      int* out_buf_size,
-                                      enum ResponseType response_type);
+// see https://github.com/wolfSSL/wolfssl-examples/blob/master/pkcs7/signedData-p7b.c for reference
+// @info out_buf_size does not reflect the size of the allocated buffer. To avaoid multiple allocations, @param out_buf allocates MAX_DECODE_SIZE bytes.
+KRITIS3M_PKI_API int
+        parseESTResponse(uint8_t* buffer, size_t buffer_size, uint8_t** out_buf, int* out_buf_size);
 
 #endif /* KRITIS3M_PKI_CLIENT_H */

--- a/library/src/kritis3m_pki_client.c
+++ b/library/src/kritis3m_pki_client.c
@@ -812,10 +812,8 @@ void signingRequest_free(SigningRequest* request)
         }
 }
 
-KRITIS3M_PKI_API int parseESTResponse(uint8_t* buffer,
-                                      size_t buffer_size,
-                                      uint8_t** out_buf,
-                                      int* out_buf_size)
+KRITIS3M_PKI_API int
+        parseESTResponse(uint8_t* buffer, size_t buffer_size, uint8_t** out_buf, int* out_buf_size)
 {
 
         int ret = 0;
@@ -879,6 +877,7 @@ KRITIS3M_PKI_API int parseESTResponse(uint8_t* buffer,
         {
                 ERROR_OUT(KRITIS3M_PKI_MEMORY_ERROR, "Unable to allocate buffer for response decoding");
         }
+
         memset(*out_buf, 0, MAX_DECODE_SIZE);
 
         uint8_t pemBuffer[MAX_DECODE_SIZE];

--- a/library/src/kritis3m_pki_logging.c
+++ b/library/src/kritis3m_pki_logging.c
@@ -12,7 +12,7 @@ static kritis3m_pki_log_callback pki_log_callback = NULL;
 static bool pki_log_enabled = false;
 
 /* Internal method declarations */
-void wolfssl_logging_callback(int level, const char* str);
+static void wolfssl_logging_callback(int level, const char* str);
 void kritis3m_pki_default_log_callback(int32_t level, char const* message);
 
 int kritis3m_pki_prepare_logging(kritis3m_pki_configuration const* config)
@@ -60,7 +60,7 @@ void pki_log(int32_t level, char const* message, ...)
                 pki_log_callback(level, buffer);
 }
 
-void wolfssl_logging_callback(int level, const char* str)
+static void wolfssl_logging_callback(int level, const char* str)
 {
         (void) level;
 


### PR DESCRIPTION
added function parseESTResponse, to parse either a chain from ca_certs or csr to .pem format. The results are written into out_buf. Multiple certs are concatenated. 
function: remove_pem_header_footer is only a workaround and currently only works for csr. 